### PR TITLE
Shift to setuptools, added requirements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Additional_Packages
 
 .vscode
 tags
+/pyRdfa.egg-info/PKG-INFO
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ Additional_Packages
 
 .vscode
 tags
-/pyRdfa.egg-info/PKG-INFO
 *.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
-from distutils.core import setup
+from setuptools import setup
+
+install_requires=[
+    "rdflib",
+    "html5lib<=0.95",
+]
+
 setup(name="pyRdfa",
       description="pyRdfa Libray",
       version="3.4.3",
@@ -6,6 +12,7 @@ setup(name="pyRdfa",
       author_email="ivan@w3.org",
       maintainer="Ivan Herman",
       maintainer_email="ivan@w3.org",
+      install_requires=install_requires,
       packages=['pyRdfa',
 				'pyRdfa.transform',
 				'pyRdfa.extras',


### PR DESCRIPTION
Hi!

1. I've changed distribute to setuptools so I can make
`python setup.py develop`
command.

2. I've also added prerequisite packages in the `setup.py` to enable automatic setup of `rdflib` and corresponding working `html5lib`.

Best regards,
Evgeny Cherkashin