### PR TITLE
Use latest html5lib and remove warning in README.md about it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ version in RDFLib.
 2013-08-13
 
 
-Usage Warning
--------------
-
-Warning (2013-07-16): the latest version of the html5lib package has a bug.
-This bug manifests itself if the source HTML file contains non-ASCII Unicode characters
-Until the bug is handled, users should use the older, 0.95 version. It can be downloaded
-at <https://code.google.com/p/html5lib/downloads/detail?name=html5lib-0.95.tar.gz>
-
 What is it
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 install_requires=[
     "rdflib",
-    "html5lib<=0.95",
+    "html5lib",
 ]
 
 setup(name="pyRdfa",


### PR DESCRIPTION
I have made a minor change in setup.py to use the latest available html5lib rather than the pinned version. And I have removed the warning about the latest version of html5lib from the README.

I did try this locally and it seemed to work OK.

This is against master, if you would like it against another branch let me know and I can change that.